### PR TITLE
Deploy with GitHub Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,35 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm install
+      - run: npm run build
+      - run: npm run export
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .next
 node_modules
+out

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "next start",
     "dev": "next",
-    "build": "next build"
+    "build": "next build",
+    "export": "next export"
   },
   "dependencies": {
     "next": "^9.3.5",


### PR DESCRIPTION
#1 

## 対応内容
- GitHub Pagesにdeployするためのworkflowを追加
  - https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-react-and-next
  - https://github.com/actions/cache/blob/master/examples.md#node---npm
- 静的ファイル出力用のnpm scriptを追加
  - next export

## その他

