### PR TITLE
Remove Container from _app.tx

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,19 +1,17 @@
 import React from "react";
-import { Container, AppProps } from "next/app";
+import { AppProps } from "next/app";
 import Wrapper from "../components/Wrapper";
 import Header from "../components/Header";
 import Content from "../components/Content";
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
   return (
-    <Container>
-      <Wrapper>
-        <Header />
-        <Content>
-          <Component {...pageProps} />
-        </Content>
-      </Wrapper>
-    </Container>
+    <Wrapper>
+      <Header />
+      <Content>
+        <Component {...pageProps} />
+      </Content>
+    </Wrapper>
   );
 };
 


### PR DESCRIPTION
> _app.js:9 Warning: the `Container` in `_app` has been deprecated and should be removed. https://err.sh/zeit/next.js/app-container-deprecated

## 対応内容
https://github.com/zeit/next.js/blob/master/errors/app-container-deprecated.md

## その他

