### PR TITLE
Use remark-rehype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3349,14 +3349,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.4.tgz",
       "integrity": "sha512-NFR6ljJRvDcyPP5SbV7MyPBgF47X3BsskLnmw1U34yL+X6YC0MoBx9EyMg8Jtx4FzGH95jw8+c1VPLHaRA0wDQ=="
     },
-    "hast-util-sanitize": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-2.0.2.tgz",
-      "integrity": "sha512-ppfgtI6pVb0/dopboV/N2SZju/CKEJzLs6jm58NxoYU1c1ib+/sh14JV5bjLDOEYvyeb5hYIttFKanYm0rtnHQ==",
-      "requires": {
-        "xtend": "^4.0.0"
-      }
-    },
     "hast-util-to-html": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-7.1.0.tgz",
@@ -3528,11 +3520,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
-    },
-    "is-alphanumeric": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
-      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
     },
     "is-alphanumerical": {
       "version": "1.0.4",
@@ -3829,11 +3816,6 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
-    "longest-streak": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3883,14 +3865,6 @@
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
     },
-    "markdown-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-      "requires": {
-        "repeat-string": "^1.0.0"
-      }
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -3899,14 +3873,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "mdast-util-compact": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
-      "integrity": "sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==",
-      "requires": {
-        "unist-util-visit": "^2.0.0"
       }
     },
     "mdast-util-definitions": {
@@ -5474,25 +5440,13 @@
         }
       }
     },
-    "remark": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-12.0.0.tgz",
-      "integrity": "sha512-oX4lMIS0csgk8AEbzY0h2jdR0ngiCHOpwwpxjmRa5TqAkeknY+tkhjRJGZqnCmvyuWh55/0SW5WY3R3nn3PH9A==",
+    "rehype-stringify": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-7.0.0.tgz",
+      "integrity": "sha512-u3dQI7mIWN2X1H0MBFPva425HbkXgB+M39C9SM5leUS2kh5hHUn2SxQs2c2yZN5eIHipoLMojC0NP5e8fptxvQ==",
       "requires": {
-        "remark-parse": "^8.0.0",
-        "remark-stringify": "^8.0.0",
-        "unified": "^9.0.0"
-      }
-    },
-    "remark-html": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-11.0.1.tgz",
-      "integrity": "sha512-bz7tSu9kDbaRNaiqQWrgXITkqJsZXoc2fjau+ms7WA4vflDoB+xMdY0QfNhUpGgmAv4SdDD1m+3BxWRHLizmiQ==",
-      "requires": {
-        "hast-util-sanitize": "^2.0.0",
         "hast-util-to-html": "^7.0.0",
-        "mdast-util-to-hast": "^8.0.0",
-        "xtend": "^4.0.1"
+        "xtend": "^4.0.0"
       }
     },
     "remark-parse": {
@@ -5518,25 +5472,12 @@
         "xtend": "^4.0.1"
       }
     },
-    "remark-stringify": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.0.0.tgz",
-      "integrity": "sha512-cABVYVloFH+2ZI5bdqzoOmemcz/ZuhQSH6W6ZNYnLojAUUn3xtX7u+6BpnYp35qHoGr2NFBsERV14t4vCIeW8w==",
+    "remark-rehype": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-6.0.0.tgz",
+      "integrity": "sha512-dt7cHCD2NbbmXoSnnNolk+MnWzylsOIEU07pyhZSM71Xy08xX07+yuCh+4rddyrB/a1hebygeteVEJieyCeDzg==",
       "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^2.0.0",
-        "mdast-util-compact": "^2.0.0",
-        "parse-entities": "^2.0.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^3.0.0",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
+        "mdast-util-to-hast": "^8.0.0"
       }
     },
     "remove-trailing-separator": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "next": "^9.3.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "remark": "^12.0.0",
-    "remark-html": "^11.0.1"
+    "rehype-stringify": "^7.0.0",
+    "remark-parse": "^8.0.1",
+    "remark-rehype": "^6.0.0",
+    "unified": "^9.0.0"
   },
   "devDependencies": {
     "@types/node": "^13.11.1",

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -24,7 +24,7 @@ export const getStaticProps: GetStaticProps<Prop, Param> = async ({
   const html = await createHtml(text);
   return {
     props: {
-      data: html.contents as string,
+      data: html,
     },
   };
 };

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -4,4 +4,7 @@ import html from "remark-html";
 
 const processor = remark().use(html).data("settings", { commonmark: true });
 
-export const createHtml = async (input: string) => processor.process(input);
+export const createHtml = async (input: string): Promise<string> => {
+  const data = await processor.process(input);
+  return data.contents as string;
+};

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,8 +1,14 @@
-import remark from "remark";
+import unified from "unified";
+import markdown from "remark-parse";
 // @ts-ignore
-import html from "remark-html";
+import remark2rehype from "remark-rehype";
+// @ts-ignore
+import html from "rehype-stringify";
 
-const processor = remark().use(html).data("settings", { commonmark: true });
+const processor = unified()
+  .use(markdown, { commonmark: true })
+  .use(remark2rehype)
+  .use(html);
 
 export const createHtml = async (input: string): Promise<string> => {
   const data = await processor.process(input);


### PR DESCRIPTION
#9 #10 

## 対応内容
- remark及びremark-htmlを使わない対応
  - remarkはremark-parseはremark-stringify、remark-htmlはmdast-util-to-hastやhast-util-to-htmlなどのラッパーであるため、今後間に別の処理を挟むことを考えるとより細かい単位のモジュールで構成しておいた方が良い
  - https://remark.js.org/
- Fix typing

## その他

