### PR TITLE
Extract frontmatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3283,6 +3283,17 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
+    "gray-matter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.2.tgz",
+      "integrity": "sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==",
+      "requires": {
+        "js-yaml": "^3.11.0",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5780,6 +5791,25 @@
         "ajv-keywords": "^3.4.1"
       }
     },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -6172,6 +6202,11 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
     "style-loader": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3112,6 +3112,14 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "requires": {
+        "format": "^0.2.0"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -3189,6 +3197,11 @@
         "tapable": "^1.0.0",
         "worker-rpc": "^0.1.0"
       }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -5524,6 +5537,14 @@
         "mdast-util-toc": "^5.0.3",
         "unist-util-filter": "^2.0.2",
         "unist-util-parents": "^1.0.3"
+      }
+    },
+    "remark-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-uNOQt4tO14qBFWXenF0MLC4cqo3dv8qiHPGyjCl1rwOT0LomSHpcElbjjVh5CwzElInB38HD8aSRVugKQjeyHA==",
+      "requires": {
+        "fault": "^1.0.1"
       }
     },
     "remark-parse": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "gray-matter": "^4.0.2",
     "next": "^9.3.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "remark-parse": "^8.0.1",
     "remark-rehype": "^6.0.0",
     "remark-slug": "^6.0.0",
-    "unified": "^9.0.0"
+    "unified": "^9.0.0",
+    "unist-util-filter": "^2.0.2"
   },
   "devDependencies": {
     "@types/node": "^13.11.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^16.13.1",
     "rehype-stringify": "^7.0.0",
     "remark-contents": "^0.0.1",
+    "remark-frontmatter": "^2.0.0",
     "remark-parse": "^8.0.1",
     "remark-rehype": "^6.0.0",
     "remark-slug": "^6.0.0",

--- a/src/articles/test.md
+++ b/src/articles/test.md
@@ -1,3 +1,11 @@
+---
+layout: post
+title: "Test記事"
+date: 2020-04-30 22:34
+comments: true
+categories: [JavaScript, React]
+---
+
 # Test
 
 ああああ

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -1,10 +1,18 @@
 import { NextPage, GetStaticProps, GetStaticPaths } from "next";
-import { createHtml, createContents } from "../../utils/markdown";
+import {
+  createHtml,
+  createContents,
+  extractFrontmatter,
+} from "../../utils/markdown";
 import { readArticle, readArticles } from "../../utils/article";
 import Toc from "../../components/Toc";
 
 type Param = { id: string };
-type Prop = { textHtml: string; tocHtml: string };
+type Prop = {
+  textHtml: string;
+  tocHtml: string;
+  frontmatter: { [key: string]: any };
+};
 
 const pageStyle = {
   display: "flex",
@@ -18,9 +26,10 @@ const textStyle = {
   flex: 1,
 };
 
-const Page: NextPage<Prop> = ({ textHtml, tocHtml }) => {
+const Page: NextPage<Prop> = ({ textHtml, tocHtml, frontmatter }) => {
   return (
     <div style={pageStyle}>
+      <div>{frontmatter.title || "notitle"}</div>
       <div
         style={textStyle}
         dangerouslySetInnerHTML={{
@@ -42,6 +51,7 @@ export const getStaticProps: GetStaticProps<Prop, Param> = async ({
     props: {
       textHtml: html,
       tocHtml: toc,
+      frontmatter: extractFrontmatter(article.content),
     },
   };
 };

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -22,6 +22,10 @@ const pageStyle = {
   justifyContent: "center",
 } as const;
 
+const contentStyle = {
+  flex: 1,
+};
+
 const textStyle = {
   flex: 1,
 };
@@ -29,13 +33,17 @@ const textStyle = {
 const Page: NextPage<Prop> = ({ textHtml, tocHtml, frontmatter }) => {
   return (
     <div style={pageStyle}>
-      <div>{frontmatter.title || "notitle"}</div>
-      <div
-        style={textStyle}
-        dangerouslySetInnerHTML={{
-          __html: textHtml,
-        }}
-      />
+      <div style={contentStyle}>
+        <div>
+          <h1>{frontmatter.title || "notitle"}</h1>
+        </div>
+        <div
+          style={textStyle}
+          dangerouslySetInnerHTML={{
+            __html: textHtml,
+          }}
+        />
+      </div>
       <Toc html={tocHtml} />
     </div>
   );

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,8 +1,9 @@
 import { NextPage, GetStaticProps } from "next";
 import Link from "next/link";
-import { readArticles, Article } from "../../utils/article";
+import { readArticles } from "../../utils/article";
+import { extractFrontmatter } from "../../utils/markdown";
 
-type Prop = { articles: Article[] };
+type Prop = { articles: { id: string; frontmatter: { [key: string]: any } }[] };
 
 const Page: NextPage<Prop> = ({ articles }) => {
   return (
@@ -10,7 +11,9 @@ const Page: NextPage<Prop> = ({ articles }) => {
       {articles.map((d) => (
         <div key={d.id}>
           <Link href={`/blog/${d.id}`}>
-            <a>{d.id + " - " + d.content}</a>
+            <a>{`${d.frontmatter.date || "nodate"} - ${
+              d.frontmatter.title || "notitle"
+            }`}</a>
           </Link>
         </div>
       ))}
@@ -20,9 +23,15 @@ const Page: NextPage<Prop> = ({ articles }) => {
 
 export const getStaticProps: GetStaticProps<Prop> = async () => {
   const articles = readArticles();
+
   return {
     props: {
-      articles,
+      articles: articles.map((a) => {
+        return {
+          id: a.id,
+          frontmatter: extractFrontmatter(a.content),
+        };
+      }),
     },
   };
 };

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -7,6 +7,7 @@ import html from "rehype-stringify";
 // @ts-ignore
 import slug from "remark-slug";
 import contents from "remark-contents";
+import matter, { GrayMatterFile } from "gray-matter";
 
 const processor = unified()
   .use(markdown, { commonmark: true })
@@ -30,4 +31,10 @@ export const createHtml = async (input: string): Promise<string> => {
 export const createContents = async (input: string): Promise<string> => {
   const data = await contentsProcessor().process(input);
   return data.contents as string;
+};
+
+export const extractFrontmatter = (
+  input: string
+): GrayMatterFile<string>["data"] => {
+  return matter(input).data;
 };

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -7,11 +7,15 @@ import html from "rehype-stringify";
 // @ts-ignore
 import slug from "remark-slug";
 import contents from "remark-contents";
+import frontmatter from "remark-frontmatter";
 import matter, { GrayMatterFile } from "gray-matter";
+import filter from "./unistFilter";
 
 const processor = unified()
   .use(markdown, { commonmark: true })
+  .use(frontmatter, ["yaml", "toml"])
   .use(slug)
+  .use(filter, ["yaml", "toml"])
   .use(remark2rehype)
   .use(html)
   .freeze();

--- a/src/utils/unistFilter.js
+++ b/src/utils/unistFilter.js
@@ -1,0 +1,15 @@
+"use strict";
+
+var uuFilter = require("unist-util-filter");
+
+module.exports = filter;
+
+function filter(types) {
+  return transformer;
+
+  function transformer(ast) {
+    return uuFilter(ast, { cascade: false }, function (node) {
+      return types.indexOf(node.type) !== -1;
+    });
+  }
+}


### PR DESCRIPTION
#9 

## 対応内容
- [gray-matter](https://github.com/jonschlinkert/gray-matter)でfrontmatter情報を抽出
  - これに基づきタイトルや日付を描画する
- コンテンツからはfrontmatter部分を除去する
  - [remark-frontmatter](https://github.com/remarkjs/remark-frontmatter)で情報付与し、[unist-util-filter](https://github.com/syntax-tree/unist-util-filter)で除去する

## その他
gray-matterではなく、remarkの文脈で抽出できるならそのように変更したい

