### PR TITLE
Replace dangerouslySetInnerHTML with rehype-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2069,11 +2069,6 @@
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
     },
-    "character-entities-html4": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
-      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
-    },
     "character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
@@ -3449,33 +3444,6 @@
         "web-namespaces": "^1.0.0"
       }
     },
-    "hast-util-is-element": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.4.tgz",
-      "integrity": "sha512-NFR6ljJRvDcyPP5SbV7MyPBgF47X3BsskLnmw1U34yL+X6YC0MoBx9EyMg8Jtx4FzGH95jw8+c1VPLHaRA0wDQ=="
-    },
-    "hast-util-to-html": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-7.1.0.tgz",
-      "integrity": "sha512-RjvNL41bYnxTOA+s8W8mjhVxH1J0dXza9hlakVHbghFsfj3JO/lsq3DsR/Md2HbynS8y89/LA7k0lhtnYJ1Yzw==",
-      "requires": {
-        "ccount": "^1.0.0",
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-whitespace": "^1.0.0",
-        "html-void-elements": "^1.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0",
-        "stringify-entities": "^3.0.0",
-        "unist-util-is": "^4.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "hast-util-whitespace": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
-      "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A=="
-    },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
@@ -3505,11 +3473,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
-    },
-    "html-void-elements": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
-      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w=="
     },
     "htmlparser2": {
       "version": "4.1.0",
@@ -5578,15 +5541,6 @@
         "hast-to-hyperscript": "^8.0.0"
       }
     },
-    "rehype-stringify": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-7.0.0.tgz",
-      "integrity": "sha512-u3dQI7mIWN2X1H0MBFPva425HbkXgB+M39C9SM5leUS2kh5hHUn2SxQs2c2yZN5eIHipoLMojC0NP5e8fptxvQ==",
-      "requires": {
-        "hast-util-to-html": "^7.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "remark-contents": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/remark-contents/-/remark-contents-0.0.1.tgz",
@@ -6260,18 +6214,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "stringify-entities": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.0.tgz",
-      "integrity": "sha512-h7NJJIssprqlyjHT2eQt2W1F+MCcNmwPGlKb0bWEdET/3N44QN3QbUF/ueKCgAssyKRZ3Br9rQ7FcXjHr0qLHw==",
-      "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.2",
-        "is-hexadecimal": "^1.0.0"
       }
     },
     "strip-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1268,6 +1268,37 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@mapbox/hast-util-table-cell-style": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz",
+      "integrity": "sha512-QsEsh5YaDvHoMQ2YHdvZy2iDnU3GgKVBTcHf6cILyoWDZtPSdlG444pL/ioPYO/GpXSfODBb9sefEetfC4v9oA==",
+      "requires": {
+        "unist-util-visit": "^1.3.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+        },
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
+      }
+    },
     "@types/mdast": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
@@ -3405,6 +3436,19 @@
         }
       }
     },
+    "hast-to-hyperscript": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-8.1.0.tgz",
+      "integrity": "sha512-NGZO5WbTxzmtMWT3wgfwCAvAofNuWovWFJ2HX0sp1xsUMafDktrijaUuR/dBFpQ0eo4nsXEE3pz17WVvYYXK4Q==",
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0",
+        "style-to-object": "^0.3.0",
+        "unist-util-is": "^4.0.0",
+        "web-namespaces": "^1.0.0"
+      }
+    },
     "hast-util-is-element": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.4.tgz",
@@ -3545,6 +3589,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -5520,6 +5569,15 @@
         }
       }
     },
+    "rehype-react": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-5.0.1.tgz",
+      "integrity": "sha512-vv/uqHROopaPimIw6Ip4Mx5+YySLClC7pSFJSW3QkwVYvguqbm5N+Cu4yJgt6nvDmOsP66GnQtDlU+tI6bhigQ==",
+      "requires": {
+        "@mapbox/hast-util-table-cell-style": "^0.1.3",
+        "hast-to-hyperscript": "^8.0.0"
+      }
+    },
     "rehype-stringify": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-7.0.0.tgz",
@@ -6258,6 +6316,14 @@
         }
       }
     },
+    "style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "requires": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
     "styled-jsx": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-3.2.5.tgz",
@@ -6933,6 +6999,11 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
+    },
+    "web-namespaces": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
     },
     "webpack": {
       "version": "4.42.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "^9.3.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "rehype-react": "^5.0.1",
     "rehype-stringify": "^7.0.0",
     "remark-contents": "^0.0.1",
     "remark-frontmatter": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "rehype-react": "^5.0.1",
-    "rehype-stringify": "^7.0.0",
     "remark-contents": "^0.0.1",
     "remark-frontmatter": "^2.0.0",
     "remark-parse": "^8.0.1",

--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -1,11 +1,11 @@
-import { createReactElement } from "../utils/markdown";
+import { createContentReact } from "../utils/markdown";
 
 const textStyle = {
   flex: 1,
 };
 
 const Component: React.FC<{ md: string }> = ({ md }) => {
-  return <div style={textStyle}>{createReactElement(md)}</div>;
+  return <div style={textStyle}>{createContentReact(md)}</div>;
 };
 
 export default Component;

--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -1,0 +1,16 @@
+const textStyle = {
+  flex: 1,
+};
+
+const Component: React.FC<{ html: string }> = ({ html }) => {
+  return (
+    <div
+      style={textStyle}
+      dangerouslySetInnerHTML={{
+        __html: html,
+      }}
+    />
+  );
+};
+
+export default Component;

--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -1,16 +1,11 @@
+import { createReactElement } from "../utils/markdown";
+
 const textStyle = {
   flex: 1,
 };
 
-const Component: React.FC<{ html: string }> = ({ html }) => {
-  return (
-    <div
-      style={textStyle}
-      dangerouslySetInnerHTML={{
-        __html: html,
-      }}
-    />
-  );
+const Component: React.FC<{ md: string }> = ({ md }) => {
+  return <div style={textStyle}>{createReactElement(md)}</div>;
 };
 
 export default Component;

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,3 +1,5 @@
+import { createContents } from "../utils/markdown";
+
 const tocStyle = {
   position: "fixed", // FIXME
   top: 100,
@@ -5,15 +7,8 @@ const tocStyle = {
   width: 300,
 } as const;
 
-const Component: React.FC<{ html: string }> = ({ html }) => {
-  return (
-    <div
-      style={tocStyle}
-      dangerouslySetInnerHTML={{
-        __html: html,
-      }}
-    />
-  );
+const Component: React.FC<{ md: string }> = ({ md }) => {
+  return <div style={tocStyle}>{createContents(md)}</div>;
 };
 
 export default Component;

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,4 +1,4 @@
-import { createContents } from "../utils/markdown";
+import { createTocReact } from "../utils/markdown";
 
 const tocStyle = {
   position: "fixed", // FIXME
@@ -8,7 +8,7 @@ const tocStyle = {
 } as const;
 
 const Component: React.FC<{ md: string }> = ({ md }) => {
-  return <div style={tocStyle}>{createContents(md)}</div>;
+  return <div style={tocStyle}>{createTocReact(md)}</div>;
 };
 
 export default Component;

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -1,5 +1,5 @@
 import { NextPage, GetStaticProps, GetStaticPaths } from "next";
-import { createContents, extractFrontmatter } from "../../utils/markdown";
+import { extractFrontmatter } from "../../utils/markdown";
 import { readArticle, readArticles } from "../../utils/article";
 import Article from "../../components/Article";
 import Toc from "../../components/Toc";
@@ -7,7 +7,6 @@ import Toc from "../../components/Toc";
 type Param = { id: string };
 type Prop = {
   textMd: string;
-  tocHtml: string;
   frontmatter: { [key: string]: any };
 };
 
@@ -23,7 +22,7 @@ const contentStyle = {
   flex: 1,
 };
 
-const Page: NextPage<Prop> = ({ textMd, tocHtml, frontmatter }) => {
+const Page: NextPage<Prop> = ({ textMd, frontmatter }) => {
   return (
     <div style={pageStyle}>
       <div style={contentStyle}>
@@ -32,7 +31,7 @@ const Page: NextPage<Prop> = ({ textMd, tocHtml, frontmatter }) => {
         </div>
         <Article md={textMd} />
       </div>
-      <Toc html={tocHtml} />
+      <Toc md={textMd} />
     </div>
   );
 };
@@ -41,11 +40,9 @@ export const getStaticProps: GetStaticProps<Prop, Param> = async ({
   params,
 }) => {
   const article = readArticle(params?.id || "");
-  const toc = await createContents(article.content);
   return {
     props: {
       textMd: article.content,
-      tocHtml: toc,
       frontmatter: extractFrontmatter(article.content),
     },
   };

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -5,6 +5,7 @@ import {
   extractFrontmatter,
 } from "../../utils/markdown";
 import { readArticle, readArticles } from "../../utils/article";
+import Article from "../../components/Article";
 import Toc from "../../components/Toc";
 
 type Param = { id: string };
@@ -26,10 +27,6 @@ const contentStyle = {
   flex: 1,
 };
 
-const textStyle = {
-  flex: 1,
-};
-
 const Page: NextPage<Prop> = ({ textHtml, tocHtml, frontmatter }) => {
   return (
     <div style={pageStyle}>
@@ -37,12 +34,7 @@ const Page: NextPage<Prop> = ({ textHtml, tocHtml, frontmatter }) => {
         <div>
           <h1>{frontmatter.title || "notitle"}</h1>
         </div>
-        <div
-          style={textStyle}
-          dangerouslySetInnerHTML={{
-            __html: textHtml,
-          }}
-        />
+        <Article html={textHtml} />
       </div>
       <Toc html={tocHtml} />
     </div>

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -6,7 +6,7 @@ import Toc from "../../components/Toc";
 
 type Param = { id: string };
 type Prop = {
-  textMd: string;
+  mdText: string;
   frontmatter: { [key: string]: any };
 };
 
@@ -22,16 +22,16 @@ const contentStyle = {
   flex: 1,
 };
 
-const Page: NextPage<Prop> = ({ textMd, frontmatter }) => {
+const Page: NextPage<Prop> = ({ mdText, frontmatter }) => {
   return (
     <div style={pageStyle}>
       <div style={contentStyle}>
         <div>
           <h1>{frontmatter.title || "notitle"}</h1>
         </div>
-        <Article md={textMd} />
+        <Article md={mdText} />
       </div>
-      <Toc md={textMd} />
+      <Toc md={mdText} />
     </div>
   );
 };
@@ -42,7 +42,7 @@ export const getStaticProps: GetStaticProps<Prop, Param> = async ({
   const article = readArticle(params?.id || "");
   return {
     props: {
-      textMd: article.content,
+      mdText: article.content,
       frontmatter: extractFrontmatter(article.content),
     },
   };

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -1,16 +1,12 @@
 import { NextPage, GetStaticProps, GetStaticPaths } from "next";
-import {
-  createHtml,
-  createContents,
-  extractFrontmatter,
-} from "../../utils/markdown";
+import { createContents, extractFrontmatter } from "../../utils/markdown";
 import { readArticle, readArticles } from "../../utils/article";
 import Article from "../../components/Article";
 import Toc from "../../components/Toc";
 
 type Param = { id: string };
 type Prop = {
-  textHtml: string;
+  textMd: string;
   tocHtml: string;
   frontmatter: { [key: string]: any };
 };
@@ -27,14 +23,14 @@ const contentStyle = {
   flex: 1,
 };
 
-const Page: NextPage<Prop> = ({ textHtml, tocHtml, frontmatter }) => {
+const Page: NextPage<Prop> = ({ textMd, tocHtml, frontmatter }) => {
   return (
     <div style={pageStyle}>
       <div style={contentStyle}>
         <div>
           <h1>{frontmatter.title || "notitle"}</h1>
         </div>
-        <Article html={textHtml} />
+        <Article md={textMd} />
       </div>
       <Toc html={tocHtml} />
     </div>
@@ -45,11 +41,10 @@ export const getStaticProps: GetStaticProps<Prop, Param> = async ({
   params,
 }) => {
   const article = readArticle(params?.id || "");
-  const html = await createHtml(article.content);
   const toc = await createContents(article.content);
   return {
     props: {
-      textHtml: html,
+      textMd: article.content,
       tocHtml: toc,
       frontmatter: extractFrontmatter(article.content),
     },

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -3,12 +3,15 @@ import markdown from "remark-parse";
 // @ts-ignore
 import remark2rehype from "remark-rehype";
 // @ts-ignore
+import rehype2react from "rehype-react";
+// @ts-ignore
 import html from "rehype-stringify";
 // @ts-ignore
 import slug from "remark-slug";
 import contents from "remark-contents";
 import frontmatter from "remark-frontmatter";
 import matter, { GrayMatterFile } from "gray-matter";
+import React from "react";
 import filter from "./unistFilter";
 
 const processor = unified()
@@ -30,6 +33,19 @@ const contentsProcessor = unified()
 export const createHtml = async (input: string): Promise<string> => {
   const data = await processor().process(input);
   return data.contents as string;
+};
+
+export const createReactElement = (input: string): React.ReactElement => {
+  const processor = unified()
+    .use(markdown, { commonmark: true })
+    .use(frontmatter, ["yaml", "toml"])
+    .use(slug)
+    .use(filter, ["yaml", "toml"])
+    .use(remark2rehype)
+    .use(rehype2react, { createElement: React.createElement });
+
+  const data = processor().processSync(input);
+  return (data as any).result as React.ReactElement;
 };
 
 export const createContents = async (input: string): Promise<string> => {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -12,7 +12,7 @@ import matter, { GrayMatterFile } from "gray-matter";
 import React from "react";
 import filter from "./unistFilter";
 
-export const createReactElement = (input: string): React.ReactElement => {
+export const createContentReact = (mdText: string): React.ReactElement => {
   const processor = unified()
     .use(markdown, { commonmark: true })
     .use(frontmatter, ["yaml", "toml"])
@@ -21,23 +21,23 @@ export const createReactElement = (input: string): React.ReactElement => {
     .use(remark2rehype)
     .use(rehype2react, { createElement: React.createElement });
 
-  const data = processor().processSync(input);
+  const data = processor().processSync(mdText);
   return (data as any).result as React.ReactElement;
 };
 
-export const createContents = (input: string): React.ReactElement => {
+export const createTocReact = (mdText: string): React.ReactElement => {
   const processor = unified()
     .use(markdown, { commonmark: true })
     .use(contents)
     .use(remark2rehype)
     .use(rehype2react, { createElement: React.createElement });
 
-  const data = processor().processSync(input);
+  const data = processor().processSync(mdText);
   return (data as any).result as React.ReactElement;
 };
 
 export const extractFrontmatter = (
-  input: string
+  mdText: string
 ): GrayMatterFile<string>["data"] => {
-  return matter(input).data;
+  return matter(mdText).data;
 };

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -23,13 +23,6 @@ const processor = unified()
   .use(html)
   .freeze();
 
-const contentsProcessor = unified()
-  .use(markdown, { commonmark: true })
-  .use(contents)
-  .use(remark2rehype)
-  .use(html)
-  .freeze();
-
 export const createHtml = async (input: string): Promise<string> => {
   const data = await processor().process(input);
   return data.contents as string;
@@ -48,9 +41,15 @@ export const createReactElement = (input: string): React.ReactElement => {
   return (data as any).result as React.ReactElement;
 };
 
-export const createContents = async (input: string): Promise<string> => {
-  const data = await contentsProcessor().process(input);
-  return data.contents as string;
+export const createContents = (input: string): React.ReactElement => {
+  const processor = unified()
+    .use(markdown, { commonmark: true })
+    .use(contents)
+    .use(remark2rehype)
+    .use(rehype2react, { createElement: React.createElement });
+
+  const data = processor().processSync(input);
+  return (data as any).result as React.ReactElement;
 };
 
 export const extractFrontmatter = (

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -5,28 +5,12 @@ import remark2rehype from "remark-rehype";
 // @ts-ignore
 import rehype2react from "rehype-react";
 // @ts-ignore
-import html from "rehype-stringify";
-// @ts-ignore
 import slug from "remark-slug";
 import contents from "remark-contents";
 import frontmatter from "remark-frontmatter";
 import matter, { GrayMatterFile } from "gray-matter";
 import React from "react";
 import filter from "./unistFilter";
-
-const processor = unified()
-  .use(markdown, { commonmark: true })
-  .use(frontmatter, ["yaml", "toml"])
-  .use(slug)
-  .use(filter, ["yaml", "toml"])
-  .use(remark2rehype)
-  .use(html)
-  .freeze();
-
-export const createHtml = async (input: string): Promise<string> => {
-  const data = await processor().process(input);
-  return data.contents as string;
-};
 
 export const createReactElement = (input: string): React.ReactElement => {
   const processor = unified()


### PR DESCRIPTION
#9 

## 対応内容
- rehype-stringify + dangerouslySetInnerHTML を [rehype-react](https://github.com/remarkjs/remark-react) で置き換え
  - unified v9.0.0から`VFile.content`ではなく`VFile.result`にrehype-reactの処理結果が入るようになっている事に注意する
    - https://github.com/unifiedjs/unified#processorprocessfile-done

## その他

