### PR TITLE
Implement scroll spy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1299,14 +1299,6 @@
         }
       }
     },
-    "@types/mdast": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-      "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-      "requires": {
-        "@types/unist": "*"
-      }
-    },
     "@types/node": {
       "version": "13.11.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
@@ -2914,6 +2906,42 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      },
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        }
+      }
+    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -2921,17 +2949,6 @@
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
-      }
-    },
-    "es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -2970,6 +2987,15 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "events": {
       "version": "3.1.0",
@@ -4012,20 +4038,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
-    },
-    "mdast-util-toc": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-5.0.3.tgz",
-      "integrity": "sha512-A3xzcgC1XFHK0+abFmbINOxjwo7Bi0Nsfp3yTgTy5JHo2q2V6YZ5BVJreDWoK3szcLlSMvHqe8WPbjY50wAkow==",
-      "requires": {
-        "@types/mdast": "^3.0.3",
-        "@types/unist": "^2.0.3",
-        "extend": "^3.0.2",
-        "github-slugger": "^1.2.1",
-        "mdast-util-to-string": "^1.0.5",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
     },
     "mdn-data": {
       "version": "2.0.4",
@@ -5587,14 +5599,12 @@
         "hast-to-hyperscript": "^8.0.0"
       }
     },
-    "remark-contents": {
+    "remark-extract-toc": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/remark-contents/-/remark-contents-0.0.1.tgz",
-      "integrity": "sha512-uaV/D1lH11R4Z0j4oUl8Gxk/eFT7/4H88jffHLXwus5zoRBSorlKxrQqUNrVZzexJblwQNr00g1TVpUqrfp78Q==",
+      "resolved": "https://registry.npmjs.org/remark-extract-toc/-/remark-extract-toc-0.0.1.tgz",
+      "integrity": "sha512-GDxLUw7S6W1JfVyrWq87kcbQWQ6vpnrHYhjA1TJyXVcfJ3S9GVQgZLt6JjOW+1J0XwF9mhz+U8fttGDzElp6KQ==",
       "requires": {
-        "mdast-util-toc": "^5.0.3",
-        "unist-util-filter": "^2.0.2",
-        "unist-util-parents": "^1.0.3"
+        "unist-util-index": "^2.0.0"
       }
     },
     "remark-frontmatter": {
@@ -6782,18 +6792,19 @@
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.5.tgz",
       "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw=="
     },
+    "unist-util-index": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-index/-/unist-util-index-2.0.0.tgz",
+      "integrity": "sha512-PvxeSsMGrTY9Elxe0cbhr2IlP9DuzcSYjfxKRYmDK53gFroN+n+rMGzBHNY8NaFU/x3C5EzrwtG8/YlJVbEmrA==",
+      "requires": {
+        "es6-map": "^0.1.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
     "unist-util-is": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
       "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
-    },
-    "unist-util-parents": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-parents/-/unist-util-parents-1.0.3.tgz",
-      "integrity": "sha512-GA82HBLgPxR+qkOzbti/jxzmkMBDu8iS/mw58iCwLpCl9JpLyGxkVr7nsFpAX956qIsa5yKNKM5SeGS8yCY8Lw==",
-      "requires": {
-        "es6-weak-map": "^2.0.0"
-      }
     },
     "unist-util-position": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5600,9 +5600,9 @@
       }
     },
     "remark-extract-toc": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/remark-extract-toc/-/remark-extract-toc-0.0.1.tgz",
-      "integrity": "sha512-GDxLUw7S6W1JfVyrWq87kcbQWQ6vpnrHYhjA1TJyXVcfJ3S9GVQgZLt6JjOW+1J0XwF9mhz+U8fttGDzElp6KQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/remark-extract-toc/-/remark-extract-toc-0.1.1.tgz",
+      "integrity": "sha512-i1XmtU9j8Fxx2U9USbYK7R8qeU1xiObpd+q/7rlYFIwV4PDTqkc2+yEbamAZKcxk26dLgr96V/7BPXD68fdYEA==",
       "requires": {
         "unist-util-index": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^16.13.1",
     "rehype-highlight": "^4.0.0",
     "rehype-react": "^5.0.1",
-    "remark-contents": "^0.0.1",
+    "remark-extract-toc": "0.0.1",
     "remark-frontmatter": "^2.0.0",
     "remark-parse": "^8.0.1",
     "remark-rehype": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^16.13.1",
     "rehype-highlight": "^4.0.0",
     "rehype-react": "^5.0.1",
-    "remark-extract-toc": "0.0.1",
+    "remark-extract-toc": "0.1.1",
     "remark-frontmatter": "^2.0.0",
     "remark-parse": "^8.0.1",
     "remark-rehype": "^6.0.0",

--- a/src/articles/test.md
+++ b/src/articles/test.md
@@ -6,37 +6,85 @@ comments: true
 categories: [JavaScript, React]
 ---
 
+# heading 1
+
+## heading 2
+
+### heading 3
+
+#### heading 4
+
+##### heading 5
+
+###### heading 6
+
 # Test
 
-ああああ
+あああああああああ
+**ああああああああああ**
+~~あああああああああ~~
+
+- list
+
+  - list
+    - list
+  - list
+  - list
+
+- [ ] check
+- [x] check
+
+1. list
+1. list
+1. list
 
 ## bbbb
 
+[GitHub.com](https://github.com/)
+
 aa
+
+`aaaaa`
+
+> 引用
+
+> > 引用
+
+| Left align | Right align | Center align |
+| :--------- | ----------: | :----------: |
+| This       |        This |     This     |
+| column     |      column |    column    |
+| will       |        will |     will     |
+| be         |          be |      be      |
+| left       |       right |    center    |
+| aligned    |     aligned |   aligned    |
 
 ## cccc
 
-`aaa`
+---
 
-```
-aaa
-```
+border
+
+---
 
 ```css
 @font-face {
-  font-family: Chunkfive; src: url('Chunkfive.otf');
+  font-family: Chunkfive;
+  src: url("Chunkfive.otf");
 }
 
-body, .usertext {
-  color: #F0F0F0; background: #600;
+body,
+.usertext {
+  color: #f0f0f0;
+  background: #600;
   font-family: Chunkfive, sans;
   --heading-1: 30px/32px Helvetica, sans-serif;
 }
 
 @import url(print.css);
 @media print {
-  a[href^=http]::after {
-    content: attr(href)
+  a[href^="http"]::after {
+    content: attr(href);
   }
 }
 ```

--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -1,11 +1,18 @@
 import { createContentReact } from "../utils/markdown";
 
-const textStyle = {
-  flex: 1,
-};
-
 const Component: React.FC<{ md: string }> = ({ md }) => {
-  return <div style={textStyle}>{createContentReact(md, {})}</div>;
+  return (
+    <div className="article">
+      {createContentReact(md, {})}
+      <style jsx>
+        {`
+          .article {
+            flex: 1;
+          }
+        `}
+      </style>
+    </div>
+  );
 };
 
 export default Component;

--- a/src/components/ArticleHeader.tsx
+++ b/src/components/ArticleHeader.tsx
@@ -1,15 +1,18 @@
 import { SPACING } from "../constants/styles";
 
-const style = {
-  marginBottom: SPACING * 6,
-} as const;
-
 const Component: React.FC<{ frontmatter: { [key: string]: any } }> = ({
   frontmatter,
 }) => {
   return (
-    <div style={style}>
+    <div className="header">
       <h1>{frontmatter.title || "notitle"}</h1>
+      <style jsx>
+        {`
+          .header {
+            margin-bottom: ${SPACING * 6}px;
+          }
+        `}
+      </style>
     </div>
   );
 };

--- a/src/components/ArticleHeader.tsx
+++ b/src/components/ArticleHeader.tsx
@@ -1,0 +1,17 @@
+import { SPACING } from "../constants/styles";
+
+const style = {
+  marginBottom: SPACING * 6,
+} as const;
+
+const Component: React.FC<{ frontmatter: { [key: string]: any } }> = ({
+  frontmatter,
+}) => {
+  return (
+    <div style={style}>
+      <h1>{frontmatter.title || "notitle"}</h1>
+    </div>
+  );
+};
+
+export default Component;

--- a/src/components/ArticleWrapper.tsx
+++ b/src/components/ArticleWrapper.tsx
@@ -5,19 +5,24 @@ import {
   SPACING,
 } from "../constants/styles";
 
-const contentStyle = {
-  flex: 1,
-  border: `solid ${BORDER_WIDTH}px ${COLOR_GRAY}`,
-  borderRadius: BORDER_RADIUS,
-  paddingTop: SPACING * 4,
-  paddingBottom: SPACING * 4,
-  paddingLeft: SPACING * 6,
-  paddingRight: SPACING * 6,
-  maxWidth: 800,
-} as const;
-
 const Component: React.FC<{}> = ({ children }) => (
-  <div style={contentStyle}>{children}</div>
+  <div>
+    {children}
+    <style jsx>
+      {`
+        div {
+          flex: 1;
+          border: solid ${BORDER_WIDTH}px ${COLOR_GRAY};
+          border-radius: ${BORDER_RADIUS}px;
+          padding-top: ${SPACING * 4}px;
+          padding-bottom: ${SPACING * 4}px;
+          padding-left: ${SPACING * 6}px;
+          padding-right: ${SPACING * 6}px;
+          max-width: 800px;
+        }
+      `}
+    </style>
+  </div>
 );
 
 export default Component;

--- a/src/components/ArticleWrapper.tsx
+++ b/src/components/ArticleWrapper.tsx
@@ -1,0 +1,23 @@
+import {
+  BORDER_RADIUS,
+  BORDER_WIDTH,
+  COLOR_GRAY,
+  SPACING,
+} from "../constants/styles";
+
+const contentStyle = {
+  flex: 1,
+  border: `solid ${BORDER_WIDTH}px ${COLOR_GRAY}`,
+  borderRadius: BORDER_RADIUS,
+  paddingTop: SPACING * 4,
+  paddingBottom: SPACING * 4,
+  paddingLeft: SPACING * 6,
+  paddingRight: SPACING * 6,
+  maxWidth: 800,
+} as const;
+
+const Component: React.FC<{}> = ({ children }) => (
+  <div style={contentStyle}>{children}</div>
+);
+
+export default Component;

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -1,13 +1,20 @@
 import { SPACING } from "../constants/styles";
 
-const layoutStyle = {
-  flex: 1,
-  padding: SPACING,
-  overflowY: "auto",
-} as const;
-
 const Component: React.FC<{}> = ({ children }) => (
-  <div style={layoutStyle}>{children}</div>
+  <div>
+    {children}
+    <style jsx>
+      {`
+        div {
+          flex: 1;
+          padding-top: 0px;
+          padding-bottom: ${SPACING}px;
+          padding-left: ${SPACING}px;
+          padding-right: ${SPACING}px;
+        }
+      `}
+    </style>
+  </div>
 );
 
 export default Component;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -44,8 +44,11 @@ const Component: React.FC<{}> = () => {
       <style jsx>
         {`
           .header {
+            position: sticky;
+            top: 0px;
             display: flex;
-            padding: ${SPACING}px;
+            padding-top: ${SPACING}px;
+            padding-bottom: ${SPACING}px;
           }
           .tab-area {
             display: flex;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,26 +3,6 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { SPACING } from "../constants/styles";
 
-const headerStyle = {
-  display: "flex",
-  padding: SPACING,
-} as const;
-
-const tabAreaStyle = {
-  display: "flex",
-  flex: 1,
-  alignItems: "center",
-} as const;
-
-const iconAreaStyle = {
-  display: "flex",
-  alignItems: "center",
-} as const;
-
-const iconImageStyle = {
-  verticalAlign: "middle",
-} as const;
-
 const LinkTab: React.FC<{ href: string; title: string }> = ({
   href,
   title,
@@ -44,23 +24,43 @@ const LinkTab: React.FC<{ href: string; title: string }> = ({
 
 const Component: React.FC<{}> = () => {
   return (
-    <div style={headerStyle}>
-      <div style={tabAreaStyle}>
+    <div className="header">
+      <div className="tab-area">
         <LinkTab href="/" title="Home" />
         <LinkTab href="/about" title="About" />
         <LinkTab href="/blog" title="Blog" />
       </div>
-      <div style={iconAreaStyle}>
+      <div className="icon-area">
         <Link href="//github.com/n-inokawa">
           <a>
             <img
-              style={iconImageStyle}
+              className="icon-image"
               src="/icons/GitHub-Mark-32px.png"
               alt="GitHub"
             />
           </a>
         </Link>
       </div>
+      <style jsx>
+        {`
+          .header {
+            display: flex;
+            padding: ${SPACING}px;
+          }
+          .tab-area {
+            display: flex;
+            flex: 1;
+            align-items: center;
+          }
+          .icon-area {
+            display: flex;
+            align-items: center;
+          }
+          .icon-image {
+            vertical-align: middle;
+          }
+        `}
+      </style>
     </div>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -51,7 +51,7 @@ const Component: React.FC<{}> = () => {
         <LinkTab href="/blog" title="Blog" />
       </div>
       <div style={iconAreaStyle}>
-        <Link href="https://github.com/n-inokawa">
+        <Link href="//github.com/n-inokawa">
           <a>
             <img
               style={iconImageStyle}

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { extractToc, Toc } from "../utils/markdown";
 import { SPACING, COLOR_LIGHT_GRAY, BORDER_RADIUS } from "../constants/styles";
+import Link from "next/link";
 
 const tocStyle = {
   position: "sticky",
@@ -12,7 +13,9 @@ const tocStyle = {
 const createNode = (node: Toc): React.ReactNode => (
   <ul>
     <li>
-      <a>{`${node.value}`}</a>
+      <Link href={`#${node.data.id}`}>
+        <a>{`${node.value}`}</a>
+      </Link>
       {node.children.map(createNode)}
     </li>
     <style jsx>

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { extractToc, Toc } from "../utils/markdown";
+import { extractToc, Toc, extractIdFromToc } from "../utils/markdown";
 import {
   SPACING,
   COLOR_LIGHT_GRAY,
@@ -7,14 +7,17 @@ import {
   COLOR_BLACK,
 } from "../constants/styles";
 import Link from "next/link";
+import { useScrollSpy } from "../hooks/useScrollSpy";
 
-const createNode = (node: Toc): React.ReactNode => (
+const createNode = (node: Toc, section: string): React.ReactNode => (
   <ul key={node.data.id}>
     <li>
       <Link href={`#${node.data.id}`}>
-        <a>{`${node.value}`}</a>
+        <a
+          className={node.data.id === section ? "selected" : undefined}
+        >{`${node.value}`}</a>
       </Link>
-      {node.children.map(createNode)}
+      {node.children.map((n) => createNode(n, section))}
     </li>
     <style jsx>
       {`
@@ -39,6 +42,7 @@ const createNode = (node: Toc): React.ReactNode => (
 
           transition: all 0.1s ease-in-out;
         }
+        a.selected,
         a:hover {
           filter: opacity(50%);
         }
@@ -49,10 +53,11 @@ const createNode = (node: Toc): React.ReactNode => (
 
 const Component: React.FC<{ md: string }> = ({ md }) => {
   const nodes = extractToc(md);
+  const section = useScrollSpy(extractIdFromToc(nodes));
 
   return (
     <nav>
-      {nodes.map(createNode)}
+      {nodes.map((n) => createNode(n, section))}
       <style jsx>
         {`
           nav {

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -8,13 +8,6 @@ import {
 } from "../constants/styles";
 import Link from "next/link";
 
-const tocStyle = {
-  position: "sticky",
-  alignSelf: "start",
-  top: 0,
-  width: 300,
-} as const;
-
 const createNode = (node: Toc): React.ReactNode => (
   <ul>
     <li>
@@ -57,7 +50,21 @@ const createNode = (node: Toc): React.ReactNode => (
 const Component: React.FC<{ md: string }> = ({ md }) => {
   const nodes = extractToc(md);
 
-  return <nav style={tocStyle}>{nodes.map(createNode)}</nav>;
+  return (
+    <nav>
+      {nodes.map(createNode)}
+      <style jsx>
+        {`
+          nav {
+            position: sticky;
+            align-self: start;
+            top: 0px;
+            width: 300px;
+          }
+        `}
+      </style>
+    </nav>
+  );
 };
 
 export default Component;

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,14 +1,14 @@
 import { createTocReact } from "../utils/markdown";
 
 const tocStyle = {
-  position: "fixed", // FIXME
-  top: 100,
-  right: 0,
+  position: "sticky",
+  alignSelf: "start",
+  top: 0,
   width: 300,
 } as const;
 
 const Component: React.FC<{ md: string }> = ({ md }) => {
-  return <div style={tocStyle}>{createTocReact(md, {})}</div>;
+  return <nav style={tocStyle}>{createTocReact(md, {})}</nav>;
 };
 
 export default Component;

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,4 +1,5 @@
 import { createTocReact } from "../utils/markdown";
+import { SPACING, COLOR_LIGHT_GRAY, BORDER_RADIUS } from "../constants/styles";
 
 const tocStyle = {
   position: "sticky",
@@ -7,8 +8,65 @@ const tocStyle = {
   width: 300,
 } as const;
 
+const Ul: React.FC<{}> = ({ children }) => (
+  <ul>
+    {children}
+    <style jsx>
+      {`
+        ul {
+          margin: 0;
+          padding-top: 0px;
+          padding-bottom: 0px;
+          padding-right: 0px;
+          padding-left: ${SPACING}px;
+        }
+      `}
+    </style>
+  </ul>
+);
+
+const Li: React.FC<{}> = ({ children }) => (
+  <li>
+    {children}
+    <style jsx>
+      {`
+        li {
+          list-style-type: none;
+        }
+      `}
+    </style>
+  </li>
+);
+
+const P: React.FC<{}> = ({ children }) => <>{children}</>;
+
+const A: React.FC<{}> = ({ children }) => (
+  <div>
+    {children}
+    <style jsx>
+      {`
+        div {
+          background-color: ${COLOR_LIGHT_GRAY};
+          padding: ${SPACING / 2}px;
+          margin: ${SPACING / 2}px;
+          border-radius: ${BORDER_RADIUS}px;
+        }
+      `}
+    </style>
+  </div>
+);
+
 const Component: React.FC<{ md: string }> = ({ md }) => {
-  return <nav style={tocStyle}>{createTocReact(md, {})}</nav>;
+  return (
+    <nav style={tocStyle}>
+      {createTocReact(md, {
+        ul: Ul,
+        li: Li,
+        p: P,
+        a: A,
+      })}
+    </nav>
+  );
 };
 
 export default Component;

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { createTocReact } from "../utils/markdown";
 import { SPACING, COLOR_LIGHT_GRAY, BORDER_RADIUS } from "../constants/styles";
 
@@ -41,19 +42,25 @@ const Li: React.FC<{}> = ({ children }) => (
 const P: React.FC<{}> = ({ children }) => <>{children}</>;
 
 const A: React.FC<{}> = ({ children }) => (
-  <div>
+  <a>
     {children}
     <style jsx>
       {`
-        div {
+        a {
+          display: block;
           background-color: ${COLOR_LIGHT_GRAY};
           padding: ${SPACING / 2}px;
           margin: ${SPACING / 2}px;
           border-radius: ${BORDER_RADIUS}px;
+
+          transition: all 0.1s ease-in-out;
+        }
+        a:hover {
+          filter: opacity(50%);
         }
       `}
     </style>
-  </div>
+  </a>
 );
 
 const Component: React.FC<{ md: string }> = ({ md }) => {

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { extractToc, Toc } from "../utils/markdown";
-import { SPACING, COLOR_LIGHT_GRAY, BORDER_RADIUS } from "../constants/styles";
+import {
+  SPACING,
+  COLOR_LIGHT_GRAY,
+  BORDER_RADIUS,
+  COLOR_BLACK,
+} from "../constants/styles";
 import Link from "next/link";
 
 const tocStyle = {
@@ -36,6 +41,8 @@ const createNode = (node: Toc): React.ReactNode => (
           padding: ${SPACING / 2}px;
           margin: ${SPACING / 2}px;
           border-radius: ${BORDER_RADIUS}px;
+          text-decoration: none;
+          color: ${COLOR_BLACK};
 
           transition: all 0.1s ease-in-out;
         }

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -9,7 +9,7 @@ import {
 import Link from "next/link";
 
 const createNode = (node: Toc): React.ReactNode => (
-  <ul>
+  <ul key={node.data.id}>
     <li>
       <Link href={`#${node.data.id}`}>
         <a>{`${node.value}`}</a>

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { createTocReact } from "../utils/markdown";
+import { extractToc, Toc } from "../utils/markdown";
 import { SPACING, COLOR_LIGHT_GRAY, BORDER_RADIUS } from "../constants/styles";
 
 const tocStyle = {
@@ -39,8 +39,6 @@ const Li: React.FC<{}> = ({ children }) => (
   </li>
 );
 
-const P: React.FC<{}> = ({ children }) => <>{children}</>;
-
 const A: React.FC<{}> = ({ children }) => (
   <a>
     {children}
@@ -63,17 +61,19 @@ const A: React.FC<{}> = ({ children }) => (
   </a>
 );
 
+const createNode = (node: Toc): React.ReactNode => (
+  <Ul>
+    <Li>
+      <A>{`${node.value}`}</A>
+      {node.children.map(createNode)}
+    </Li>
+  </Ul>
+);
+
 const Component: React.FC<{ md: string }> = ({ md }) => {
-  return (
-    <nav style={tocStyle}>
-      {createTocReact(md, {
-        ul: Ul,
-        li: Li,
-        p: P,
-        a: A,
-      })}
-    </nav>
-  );
+  const nodes = extractToc(md);
+
+  return <nav style={tocStyle}>{nodes.map(createNode)}</nav>;
 };
 
 export default Component;

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -9,9 +9,12 @@ const tocStyle = {
   width: 300,
 } as const;
 
-const Ul: React.FC<{}> = ({ children }) => (
+const createNode = (node: Toc): React.ReactNode => (
   <ul>
-    {children}
+    <li>
+      <a>{`${node.value}`}</a>
+      {node.children.map(createNode)}
+    </li>
     <style jsx>
       {`
         ul {
@@ -21,29 +24,9 @@ const Ul: React.FC<{}> = ({ children }) => (
           padding-right: 0px;
           padding-left: ${SPACING}px;
         }
-      `}
-    </style>
-  </ul>
-);
-
-const Li: React.FC<{}> = ({ children }) => (
-  <li>
-    {children}
-    <style jsx>
-      {`
         li {
           list-style-type: none;
         }
-      `}
-    </style>
-  </li>
-);
-
-const A: React.FC<{}> = ({ children }) => (
-  <a>
-    {children}
-    <style jsx>
-      {`
         a {
           display: block;
           background-color: ${COLOR_LIGHT_GRAY};
@@ -58,16 +41,7 @@ const A: React.FC<{}> = ({ children }) => (
         }
       `}
     </style>
-  </a>
-);
-
-const createNode = (node: Toc): React.ReactNode => (
-  <Ul>
-    <Li>
-      <A>{`${node.value}`}</A>
-      {node.children.map(createNode)}
-    </Li>
-  </Ul>
+  </ul>
 );
 
 const Component: React.FC<{ md: string }> = ({ md }) => {

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -1,5 +1,6 @@
 export const SPACING = 20 as const;
 export const BORDER_RADIUS = 4 as const;
 export const BORDER_WIDTH = 1 as const;
+export const COLOR_BLACK = "black";
 export const COLOR_GRAY = "lightgray";
 export const COLOR_LIGHT_GRAY = "whitesmoke";

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -1,25 +1,28 @@
 import React from "react";
+import { throttle } from "../utils/timer";
 
 export const useScrollSpy = (ids: string[]): string => {
   const [section, setSection] = React.useState<string>("");
 
-  // TODO debounce
-  const spyScroll = React.useCallback(() => {
-    ids.some((id, i) => {
-      const elem = document.getElementById(id);
-      const nextElem = document.getElementById(ids[i + 1]);
-      if (!elem) {
-        return false;
-      }
-      if (
-        window.scrollY > elem.offsetTop &&
-        (!nextElem || window.scrollY < nextElem.offsetTop)
-      ) {
-        setSection(id);
-        return true;
-      }
-    });
-  }, [ids]);
+  const spyScroll = React.useCallback(
+    throttle(() => {
+      ids.some((id, i) => {
+        const elem = document.getElementById(id);
+        const nextElem = document.getElementById(ids[i + 1]);
+        if (!elem) {
+          return false;
+        }
+        if (
+          window.scrollY > elem.offsetTop &&
+          (!nextElem || window.scrollY < nextElem.offsetTop)
+        ) {
+          setSection(id);
+          return true;
+        }
+      });
+    }, 100),
+    [ids]
+  );
 
   React.useEffect(() => {
     window.addEventListener("scroll", spyScroll);

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -1,0 +1,32 @@
+import React from "react";
+
+export const useScrollSpy = (ids: string[]): string => {
+  const [section, setSection] = React.useState<string>("");
+
+  // TODO debounce
+  const spyScroll = React.useCallback(() => {
+    ids.some((id, i) => {
+      const elem = document.getElementById(id);
+      const nextElem = document.getElementById(ids[i + 1]);
+      if (!elem) {
+        return false;
+      }
+      if (
+        window.scrollY > elem.offsetTop &&
+        (!nextElem || window.scrollY < nextElem.offsetTop)
+      ) {
+        setSection(id);
+        return true;
+      }
+    });
+  }, [ids]);
+
+  React.useEffect(() => {
+    window.addEventListener("scroll", spyScroll);
+    return () => {
+      window.removeEventListener("scroll", spyScroll);
+    };
+  }, []);
+
+  return section;
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,8 +8,8 @@ import Content from "../components/Content";
 const MyApp = ({ Component, pageProps }: AppProps) => {
   return (
     <Wrapper>
-      <Header />
       <Content>
+        <Header />
         <Component {...pageProps} />
       </Content>
     </Wrapper>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -33,12 +33,6 @@ export default class MyDocument extends Document {
               color: #333;
               font-family: sans-serif;
             }
-            h1 {
-              font-weight: 700;
-            }
-            p {
-              margin-bottom: 10px;
-            }
             
             code {
               background-color: ${COLOR_LIGHT_GRAY};

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -17,9 +17,8 @@ const pageStyle = {
   flex: 1,
   flexDirection: "row",
   alignItems: "flex-start",
-  justifyContent: "center",
+  justifyContent: "space-around",
 } as const;
-
 
 const Page: NextPage<Prop> = ({ mdText, frontmatter }) => {
   return (
@@ -28,7 +27,6 @@ const Page: NextPage<Prop> = ({ mdText, frontmatter }) => {
         <ArticleHeader frontmatter={frontmatter} />
         <Article md={mdText} />
       </ArticleWrapper>
-      </div>
       <Toc md={mdText} />
     </div>
   );

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -1,6 +1,7 @@
 import { NextPage, GetStaticProps, GetStaticPaths } from "next";
 import { extractFrontmatter } from "../../utils/markdown";
 import { readArticle, readArticles } from "../../utils/article";
+import ArticleHeader from "../../components/ArticleHeader";
 import Article from "../../components/Article";
 import ArticleWrapper from "../../components/ArticleWrapper";
 import Toc from "../../components/Toc";
@@ -24,9 +25,7 @@ const Page: NextPage<Prop> = ({ mdText, frontmatter }) => {
   return (
     <div style={pageStyle}>
       <ArticleWrapper>
-        <div>
-          <h1>{frontmatter.title || "notitle"}</h1>
-        </div>
+        <ArticleHeader frontmatter={frontmatter} />
         <Article md={mdText} />
       </ArticleWrapper>
       </div>

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -2,6 +2,7 @@ import { NextPage, GetStaticProps, GetStaticPaths } from "next";
 import { extractFrontmatter } from "../../utils/markdown";
 import { readArticle, readArticles } from "../../utils/article";
 import Article from "../../components/Article";
+import ArticleWrapper from "../../components/ArticleWrapper";
 import Toc from "../../components/Toc";
 
 type Param = { id: string };
@@ -18,18 +19,16 @@ const pageStyle = {
   justifyContent: "center",
 } as const;
 
-const contentStyle = {
-  flex: 1,
-};
 
 const Page: NextPage<Prop> = ({ mdText, frontmatter }) => {
   return (
     <div style={pageStyle}>
-      <div style={contentStyle}>
+      <ArticleWrapper>
         <div>
           <h1>{frontmatter.title || "notitle"}</h1>
         </div>
         <Article md={mdText} />
+      </ArticleWrapper>
       </div>
       <Toc md={mdText} />
     </div>

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -53,6 +53,13 @@ export const extractToc = (mdText: string): Toc[] => {
   return (data as any) as Toc[];
 };
 
+export const extractIdFromToc = (nodes: Toc[]): string[] =>
+  nodes.reduce<string[]>((acc, node) => {
+    acc.push(node.data.id);
+    acc.push(...extractIdFromToc(node.children));
+    return acc;
+  }, []);
+
 export const extractFrontmatter = (
   mdText: string
 ): GrayMatterFile<string>["data"] => {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -12,7 +12,7 @@ import frontmatter from "remark-frontmatter";
 import highlight from "rehype-highlight";
 import matter, { GrayMatterFile } from "gray-matter";
 import React from "react";
-import filter from "./unistFilter";
+import { remove } from "./unist";
 
 export const createContentReact = (
   mdText: string,
@@ -22,7 +22,7 @@ export const createContentReact = (
     .use(markdown, { commonmark: true })
     .use(frontmatter, ["yaml", "toml"])
     .use(slug)
-    .use(filter, ["yaml", "toml"])
+    .use(remove, ["yaml", "toml"])
     .use(remark2rehype)
     .use(highlight)
     .use(rehype2react, {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -6,7 +6,7 @@ import remark2rehype from "remark-rehype";
 import rehype2react from "rehype-react";
 // @ts-ignore
 import slug from "remark-slug";
-import contents from "remark-contents";
+import toc from "remark-extract-toc";
 import frontmatter from "remark-frontmatter";
 // @ts-ignore
 import highlight from "rehype-highlight";
@@ -34,18 +34,18 @@ export const createContentReact = (
   return (data as any).result as React.ReactElement;
 };
 
-export const createTocReact = (
-  mdText: string,
-  components: { [key: string]: React.ReactNode }
-): React.ReactElement => {
-  const processor = unified()
-    .use(markdown, { commonmark: true })
-    .use(contents)
-    .use(remark2rehype)
-    .use(rehype2react, { createElement: React.createElement, components });
+export type Toc = {
+  depth: number;
+  value: string;
+  children: Toc[];
+};
 
-  const data = processor().processSync(mdText);
-  return (data as any).result as React.ReactElement;
+export const extractToc = (mdText: string): Toc[] => {
+  const processor = unified().use(markdown, { commonmark: true }).use(toc);
+
+  const node = processor().parse(mdText);
+  const data = processor().runSync(node);
+  return (data as any) as Toc[];
 };
 
 export const extractFrontmatter = (

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -6,6 +6,7 @@ import remark2rehype from "remark-rehype";
 import rehype2react from "rehype-react";
 // @ts-ignore
 import slug from "remark-slug";
+// @ts-ignore
 import toc from "remark-extract-toc";
 import frontmatter from "remark-frontmatter";
 // @ts-ignore
@@ -38,10 +39,14 @@ export type Toc = {
   depth: number;
   value: string;
   children: Toc[];
+  data: { id: string };
 };
 
 export const extractToc = (mdText: string): Toc[] => {
-  const processor = unified().use(markdown, { commonmark: true }).use(toc);
+  const processor = unified()
+    .use(markdown, { commonmark: true })
+    .use(slug)
+    .use(toc, { keys: ["data"] });
 
   const node = processor().parse(mdText);
   const data = processor().runSync(node);

--- a/src/utils/timer.ts
+++ b/src/utils/timer.ts
@@ -1,0 +1,19 @@
+export const debounce = (fn: () => void, interval: number) => {
+  let timer: NodeJS.Timeout;
+  return () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      fn();
+    }, interval);
+  };
+};
+
+export const throttle = (fn: () => void, interval: number) => {
+  let lastTime = Date.now() - interval;
+  return () => {
+    if (lastTime + interval < Date.now()) {
+      lastTime = Date.now();
+      fn();
+    }
+  };
+};

--- a/src/utils/unist.js
+++ b/src/utils/unist.js
@@ -2,9 +2,7 @@
 
 var uuFilter = require("unist-util-filter");
 
-module.exports = filter;
-
-function filter(types) {
+export function remove(types) {
   return transformer;
 
   function transformer(ast) {


### PR DESCRIPTION
#9 

## 対応内容

- scroll spyの実装
  - remark-extract-tocを使用し目次のidを抽出、Tocコンポーネントに紐付ける
  - useScrollSpy hookでスクロール位置のheadingのidを取得する
    - このidと一致するidを持つ目次の色を変える
  - throttleでscroll eventを間引く
- `position: sticky;`の適用
  - Header
  - Toc

## その他
参考
https://stackoverflow.com/questions/48966691/how-to-implement-a-scrollspy-with-react
https://www.bram.us/2020/01/10/smooth-scrolling-sticky-scrollspy-navigation/
https://gist.github.com/souporserious/ce6fdfda410b72ecf1dfe33982f27e0e
